### PR TITLE
Create a work directory for mock outside of the git folder

### DIFF
--- a/src/bin/make-rpms
+++ b/src/bin/make-rpms
@@ -25,6 +25,13 @@ set -e
 specfile=$1
 tmpfiles=()
 
+#Who I'm
+ME=$(whoami)
+# What is the package name
+PACKAGE=$(basename $(pwd))
+# Informations needed from the spec file
+VERSION=$(rpm -q --qf "%{version}\n" --specfile $PACKAGE.spec | head -1)
+
 if [ -z "${specfile}" ]; then
     exec >&2
     echo "Build RPMs with mock"
@@ -90,8 +97,11 @@ else
     echo "" >&2
 fi
 
+#ensure that the folder exists
+mkdir -p /home/$ME/exchange
+
 make-srpm ${specfile}
 srpm=$(basename "$(grep '^Wrote: ' build.log | tail -1 )")
 mock -D "dist .${dist}" \
-     --resultdir=. -r ${mockcfg} ${srpm}
+     --resultdir=/home/$ME/exchange/$PACKAGE-$VERSION -r ${mockcfg} ${srpm}
 

--- a/src/bin/make-srpm
+++ b/src/bin/make-srpm
@@ -26,8 +26,18 @@ specfile=$1
 export LANG=C
 export mockcfg=${mockcfg:-nethserver-6.6-x86_64}
 
+#Who I'm
+ME=$(whoami)
+# What is the package name
+PACKAGE=$(basename $(pwd))
+# Informations needed from the spec file
+VERSION=$(rpm -q --qf "%{version}\n" --specfile $PACKAGE.spec | head -1)
+
+#ensure that the folder exists
+mkdir -p /home/$ME/exchange
+
 prep-sources ${specfile}
-mock --resultdir=. -r "${mockcfg}" -D "dist .${dist:-ns6}" \
+mock --resultdir=/home/$ME/exchange/$PACKAGE-$VERSION -r "${mockcfg}" -D "dist .${dist:-ns6}" \
      --buildsrpm --spec "${specfile}" --sources .
 
 


### PR DESCRIPTION
With that patch I can get a clean git folder without results of rpm build (binaries, logs....)

Imagine that you do a 'git add .' with all build results, you will have a mess quickly.

mock uses a folder called 'exchange' in the user's home
