### PR TITLE
upload-rpms: remove preserve options

### DIFF
--- a/src/bin/upload-rpms
+++ b/src/bin/upload-rpms
@@ -41,7 +41,7 @@ fi
     echo "cd ${spool}";
     for F in $*;
     do
-        echo "put -p $F";
+        echo "put $F";
     done;
     echo "cd ..";
     echo "rename ${spool} commit-${spool}" 


### PR DESCRIPTION
Avoid the following error when uploading rpms:

  Couldn't fsetstat: Permission denied