### PR TITLE
Import README.rst

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,3 +1,5 @@
+.. _nethserver-mock-module:
+
 nethserver-mock
 ===============
 
@@ -121,3 +123,8 @@ signature from the filesystem. Sample invocation::
    sign-rpms -f ~/.secret -k ABCDABCD
 
 The signature is added automatically by ``packages.nethserver.org``.
+
+
+.. rubric:: References
+
+.. [#FedoraPG] Referencing Source http://fedoraproject.org/wiki/Packaging:SourceURL


### PR DESCRIPTION
Move documentation from the developer manual to the local README.rst. The nethserver-mock package is going to be obsoleted by ``nethserver-makerpms``.

See https://github.com/NethServer/nethserver-makerpms/pull/5