### PR TITLE
Remove deprecated 'yum localinstall' command.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -15,7 +15,7 @@ On **NethServer**, install ``nethserver-mock`` package, by typing: ::
 
 On **Fedora**, and other RPM-based distros run the command: ::
 
-  yum localinstall <URL>
+  yum install <URL>
 
 Or ::
 


### PR DESCRIPTION
"yum localinstall" has been deprecated in favor of "yum install".  See the yum manpage:
```
       localinstall
              Is used to install a set of local rpm files. If required the enabled repositories will be used to  resolve  depen‐
              dencies.  Note  that  the install command will do a local install, if given a filename. This command is maintained
              for legacy reasons only.
```
and
```
        * localinstall rpmfile1 [rpmfile2] [...]
           (maintained for legacy reasons only - use install)
```