### PR TITLE
Fix src RPM name capturing

### DIFF
--- a/src/bin/make-rpms
+++ b/src/bin/make-rpms
@@ -108,6 +108,6 @@ else
 fi
 
 make-srpm ${specfile}
-srpm=$(basename "$(grep '^Wrote: ' build.log | tail -1 )")
+srpm=$(basename "$(grep '^Wrote: ' build.log | tail -1 | tr -d '\r')")
 mock -D "dist .${dist}" \
      --resultdir=. -r ${mockcfg} ${srpm} $clean_option


### PR DESCRIPTION
See https://community.nethserver.org/t/make-rpms-fails-with-an-error/13963