### PR TITLE
Fix build on Fedora 31

### DIFF
--- a/src/mock/nethserver-6-x86_64.cfg
+++ b/src/mock/nethserver-6-x86_64.cfg
@@ -13,6 +13,7 @@ config_opts['plugin_conf']['ccache_enable'] = False
 config_opts['macros']['%url_prefix'] = 'http://dev.nethserver.org/projects/nethserver/wiki'
 config_opts['macros']['%vendor'] = 'NethServer'
 config_opts['use_nspawn'] = False
+config_opts['package_manager'] = 'yum'
 
 # Substitute $releasever and $basearch:
 config_opts['yum.conf'] = string.Template("""

--- a/src/mock/nethserver-7-aarch64.cfg
+++ b/src/mock/nethserver-7-aarch64.cfg
@@ -13,6 +13,7 @@ config_opts['plugin_conf']['ccache_enable'] = False
 config_opts['macros']['%url_prefix'] = 'http://github.com/NethServer'
 config_opts['macros']['%vendor'] = 'NethServer'
 config_opts['macros']['%dist'] = '.ns7'
+config_opts['package_manager'] = 'yum'
 
 # Substitute $releasever and $basearch:
 config_opts['yum.conf'] = string.Template("""

--- a/src/mock/nethserver-7-armhfp.cfg
+++ b/src/mock/nethserver-7-armhfp.cfg
@@ -13,6 +13,7 @@ config_opts['plugin_conf']['ccache_enable'] = False
 config_opts['macros']['%url_prefix'] = 'http://github.com/NethServer'
 config_opts['macros']['%vendor'] = 'NethServer'
 config_opts['macros']['%dist'] = '.ns7'
+config_opts['package_manager'] = 'yum'
 
 # Substitute $releasever and $basearch:
 config_opts['yum.conf'] = string.Template("""

--- a/src/mock/nethserver-7-x86_64.cfg
+++ b/src/mock/nethserver-7-x86_64.cfg
@@ -13,6 +13,7 @@ config_opts['plugin_conf']['ccache_enable'] = False
 config_opts['macros']['%url_prefix'] = 'http://github.com/NethServer'
 config_opts['macros']['%vendor'] = 'NethServer'
 config_opts['macros']['%dist'] = 'ns7'
+config_opts['package_manager'] = 'yum'
 
 # Substitute $releasever and $basearch:
 config_opts['yum.conf'] = string.Template("""


### PR DESCRIPTION
Force package manager to yum.
Inside Fedora, yum is just and alias of dnf.

See also https://community.nethserver.org/t/make-rpms-fails-error-unable-to-find-a-match-dnf-dnf-plugins-core/15168

Thanks to @stephdl 